### PR TITLE
Forward INPUT_USE_BUNDLER variable to the shell script.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,7 @@ runs:
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        INPUT_USE_BUNDLER: ${{ inputs.use_bundler }}
 branding:
   icon: check-circle
   color: red


### PR DESCRIPTION
The `use_bundler` config option is ignored in the script. The reason is, the config variable is not forwarded to the shell script.